### PR TITLE
Fix Arduino Lint - Library is already on Library Manager Index

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -23,4 +23,4 @@ jobs:
         uses: arduino/arduino-lint-action@v1
         with:
           official: true
-          library-manager: submit # Change this to "update" once the library has been added to the Library Manager index.
+          library-manager: update


### PR DESCRIPTION
Since the library is already in the library manager index the parameter library-manager needs to be set to update.