### PR TITLE
Reuse QSPIF Block Device instance from the core if exist

### DIFF
--- a/src/Arduino_Portenta_OTA_QSPI.h
+++ b/src/Arduino_Portenta_OTA_QSPI.h
@@ -47,7 +47,9 @@ private:
 
   mbed::BlockDevice * _bd_qspi;
   mbed::FATFileSystem * _fs_qspi;
-  QSPIFBlockDevice _block_device_qspi;
+#if !defined (COMPONENT_4343W_FS)
+  QSPIFBlockDevice *qspi_bd;
+#endif
 
 };
 


### PR DESCRIPTION
The define `COMPONENT_4343W_FS` is not strictly related to the QSPI device but it is the main reason of the rework on the mbed side that has caused this init side effect, so in the end i think it is a good way to keep the changes aligned.