### PR TITLE
Make library configurable using defines

### DIFF
--- a/src/Arduino_Portenta_OTA.h
+++ b/src/Arduino_Portenta_OTA.h
@@ -22,14 +22,19 @@
  * INCLUDE
  ******************************************************************************/
 
+#include "Arduino_Portenta_OTA_Config.h"
+#if defined(ARDUINO_PORTENTA_OTA_QSPI_SUPPORT)
+  #include <QSPIFBlockDevice.h>
+#endif
+
+#if defined(ARDUINO_PORTENTA_OTA_SDMMC_SUPPORT)
+  #include <SDMMCBlockDevice.h>
+#endif
+
 #include <BlockDevice.h>
 #include <MBRBlockDevice.h>
-#include <SDMMCBlockDevice.h>
-
 #include <FATFileSystem.h>
 #include <LittleFileSystem.h>
-
-#include <QSPIFBlockDevice.h>
 
 /******************************************************************************
  * DEFINE
@@ -117,7 +122,12 @@ class Arduino_Portenta_OTA
  * INCLUDE
  ******************************************************************************/
 
-#include "Arduino_Portenta_OTA_SD.h"
-#include "Arduino_Portenta_OTA_QSPI.h"
+#if defined(ARDUINO_PORTENTA_OTA_SDMMC_SUPPORT)
+  #include "Arduino_Portenta_OTA_SD.h"
+#endif
+
+#if defined(ARDUINO_PORTENTA_OTA_QSPI_SUPPORT)
+  #include "Arduino_Portenta_OTA_QSPI.h"
+#endif
 
 #endif /* ARDUINO_PORTENTA_OTA_H_ */

--- a/src/Arduino_Portenta_OTA_Config.h
+++ b/src/Arduino_Portenta_OTA_Config.h
@@ -1,0 +1,33 @@
+/*
+   This file is part of Arduino_Portenta_OTA.
+
+   Copyright 2022 ARDUINO SA (http://www.arduino.cc/)
+
+   This software is released under the GNU General Public License version 3,
+   which covers the main part of arduino-cli.
+   The terms of this license can be found at:
+   https://www.gnu.org/licenses/gpl-3.0.en.html
+
+   You can be released from the requirements of the above licenses by purchasing
+   a commercial license. Buying such a license is mandatory if you want to modify or
+   otherwise use the software for commercial activities involving the Arduino
+   software without disclosing the source code of your own applications. To purchase
+   a commercial license, send an email to license@arduino.cc.
+*/
+
+#ifndef ARDUINO_PORTENTA_OTA_CONFIG_H_
+#define ARDUINO_PORTENTA_OTA_CONFIG_H_
+
+/******************************************************************************
+ * INCLUDE
+ ******************************************************************************/
+
+#include <Arduino.h>
+
+#if defined(ARDUINO_PORTENTA_H7_M7)
+  #define ARDUINO_PORTENTA_OTA_MAGIC 0x2341025b
+  #define ARDUINO_PORTENTA_OTA_SDMMC_SUPPORT
+  #define ARDUINO_PORTENTA_OTA_QSPI_SUPPORT
+#endif
+
+#endif /* ARDUINO_PORTENTA_OTA_CONFIG_H_ */

--- a/src/Arduino_Portenta_OTA_QSPI.cpp
+++ b/src/Arduino_Portenta_OTA_QSPI.cpp
@@ -19,6 +19,9 @@
    INCLUDE
  ******************************************************************************/
 
+#include "Arduino_Portenta_OTA_Config.h"
+#if defined(ARDUINO_PORTENTA_OTA_QSPI_SUPPORT)
+
 #include "Arduino_Portenta_OTA_QSPI.h"
 
 #include <assert.h>
@@ -97,3 +100,5 @@ bool Arduino_Portenta_OTA_QSPI::open()
 
   return false;
 }
+
+#endif /* ARDUINO_PORTENTA_OTA_QSPI_SUPPORT */

--- a/src/Arduino_Portenta_OTA_QSPI.h
+++ b/src/Arduino_Portenta_OTA_QSPI.h
@@ -22,6 +22,9 @@
  * INCLUDE
  ******************************************************************************/
 
+#include "Arduino_Portenta_OTA_Config.h"
+#if defined(ARDUINO_PORTENTA_OTA_QSPI_SUPPORT)
+
 #include "Arduino_Portenta_OTA.h"
 
 /******************************************************************************
@@ -50,4 +53,5 @@ private:
   mbed::FATFileSystem * _fs_qspi;
 };
 
+#endif /* ARDUINO_PORTENTA_OTA_QSPI_SUPPORT */
 #endif /* ARDUINO_PORTENTA_OTA_QSPI_H_ */

--- a/src/Arduino_Portenta_OTA_SD.cpp
+++ b/src/Arduino_Portenta_OTA_SD.cpp
@@ -19,6 +19,9 @@
    INCLUDE
  ******************************************************************************/
 
+#include "Arduino_Portenta_OTA_Config.h"
+#if defined(ARDUINO_PORTENTA_OTA_SDMMC_SUPPORT)
+
 #include "Arduino_Portenta_OTA_SD.h"
 
 #include "BSP.h"
@@ -97,3 +100,5 @@ bool Arduino_Portenta_OTA_SD::open()
 
   return false;
 }
+
+#endif /* ARDUINO_PORTENTA_OTA_SDMMC_SUPPORT */

--- a/src/Arduino_Portenta_OTA_SD.h
+++ b/src/Arduino_Portenta_OTA_SD.h
@@ -22,6 +22,9 @@
  * INCLUDE
  ******************************************************************************/
 
+#include "Arduino_Portenta_OTA_Config.h"
+#if defined(ARDUINO_PORTENTA_OTA_SDMMC_SUPPORT)
+
 #include "Arduino_Portenta_OTA.h"
 
 /******************************************************************************
@@ -50,4 +53,5 @@ private:
 
 };
 
+#endif /* ARDUINO_PORTENTA_OTA_SDMMC_SUPPORT */
 #endif /* ARDUINO_PORTENTA_OTA_SD_H_ */

--- a/src/decompress/utility.cpp
+++ b/src/decompress/utility.cpp
@@ -179,7 +179,7 @@ int Arduino_Portenta_OTA::decompress()
 
   feedWatchdog();
 
-  if (ota_header.header.magic_number != 0x2341025b) /* 0x2341:025b = VID/PID Portenta H7 */
+  if (ota_header.header.magic_number != ARDUINO_PORTENTA_OTA_MAGIC)
   {
     fclose(update_file);
     remove(UPDATE_FILE_NAME_LZSS);


### PR DESCRIPTION
Since the library will support other platforms i've added a configuration file where is possible to change:
 - OTA_MAGIC
 - enable/disable SDMMC support
 - enable/disable QSPI support
 
In the future core releses we can add specific defines to configure the library removing board name `ARDUINO_PORTENTA_H7_M7` dependency.
 
By now the library name will remain the same, but we should think about renaming or deprecating this library and create a new one.