### PR TITLE
Redirect error prints to Serial

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -35,6 +35,8 @@ jobs:
           - fqbn: arduino:mbed:envie_m7
             platforms: |
               - name: arduino:mbed
+            libraries: |
+              - name: Arduino_DebugUtils
             sketch-paths: |
               - examples/OTA_Qspi_Flash
               - examples/OTA_SD_Portenta
@@ -42,6 +44,8 @@ jobs:
           - fqbn: arduino:mbed_nicla:nicla_vision
             platforms: |
               - name: arduino:mbed_nicla
+            libraries: |
+              - name: Arduino_DebugUtils
             sketch-paths: |
               - examples/OTA_Qspi_Flash
               - examples/OTA_Usage_Portenta
@@ -59,8 +63,7 @@ jobs:
           libraries: |
             # Install the library from the local path.
             - source-path: ./
-            # Additional library dependencies can be listed here.
-            # See: https://github.com/arduino/compile-sketches#libraries
+            ${{ matrix.board.libraries }}
           sketch-paths: |
             ${{ matrix.board.sketch-paths }}
           enable-deltas-report: true

--- a/src/Arduino_Portenta_OTA.cpp
+++ b/src/Arduino_Portenta_OTA.cpp
@@ -64,8 +64,6 @@ bool Arduino_Portenta_OTA::isOtaCapable()
 
 Arduino_Portenta_OTA::Error Arduino_Portenta_OTA::begin()
 {
-  Serial1.begin(115200);
-
   if (!isOtaCapable())
     return Error::NoCapableBootloader;
 

--- a/src/Arduino_Portenta_OTA.h
+++ b/src/Arduino_Portenta_OTA.h
@@ -35,6 +35,7 @@
 #include <MBRBlockDevice.h>
 #include <FATFileSystem.h>
 #include <LittleFileSystem.h>
+#include <Arduino_DebugUtils.h>
 
 /******************************************************************************
  * DEFINE

--- a/src/Arduino_Portenta_OTA_QSPI.cpp
+++ b/src/Arduino_Portenta_OTA_QSPI.cpp
@@ -52,7 +52,7 @@ bool Arduino_Portenta_OTA_QSPI::init()
   _bd_raw_qspi = new QSPIFBlockDevice(PD_11, PD_12, PF_7, PD_13,  PF_10, PG_6, QSPIF_POLARITY_MODE_1, 40000000);
 #endif
   if (_bd_raw_qspi->init() != QSPIF_BD_ERROR_OK) {
-    Serial1.println("Error: QSPI init failure.");
+    Debug.print(DBG_ERROR, F("Error: QSPI init failure."));
     return false;
   }
 
@@ -62,8 +62,7 @@ bool Arduino_Portenta_OTA_QSPI::init()
     int const err_mount = _fs_qspi->mount(_bd_raw_qspi);
     if (err_mount)
     {
-      Serial1.print("Error while mounting the filesystem. Err = ");
-      Serial1.println(err_mount);
+      Debug.print(DBG_ERROR, F("Error while mounting the filesystem. Err = %d"), err_mount);
       return false;
     }
     return true;
@@ -75,8 +74,7 @@ bool Arduino_Portenta_OTA_QSPI::init()
     _fs_qspi = new mbed::FATFileSystem("fs");
     int const err_mount = _fs_qspi->mount(_bd_qspi);
     if (err_mount) {
-      Serial1.print("Error while mounting the filesystem. Err = ");
-      Serial1.println(err_mount);
+      Debug.print(DBG_ERROR, F("Error while mounting the filesystem. Err = %d"), err_mount);
       return false;
     }
     return true;

--- a/src/Arduino_Portenta_OTA_SD.cpp
+++ b/src/Arduino_Portenta_OTA_SD.cpp
@@ -61,8 +61,7 @@ bool Arduino_Portenta_OTA_SD::init()
     _fs_sd = new mbed::FATFileSystem("fs");
     int const err =  _fs_sd->mount(&_block_device);
     if (err) {
-      Serial1.print("Error while mounting the filesystem. Err = ");
-      Serial1.println(err);
+      Debug.print(DBG_ERROR, F("Error while mounting the filesystem. Err = %d"), err);
       return false;
     }
     return true;
@@ -75,8 +74,7 @@ bool Arduino_Portenta_OTA_SD::init()
     int const err =  _fs_sd->mount(_bd);
     if (err)
     {
-      Serial1.print("Error while mounting the filesystem. Err = ");
-      Serial1.println(err);
+      Debug.print(DBG_ERROR, F("Error while mounting the filesystem. Err = %d"), err);
       return false;
     }
     return true;


### PR DESCRIPTION
This library used to print errors on `Serial1`. Thei PR includes Arduino_DebugUtils to move them to `Serial` and standardize prints format.