### PR TITLE
Add support for ethernet interface

### DIFF
--- a/src/Arduino_Portenta_OTA.h
+++ b/src/Arduino_Portenta_OTA.h
@@ -84,6 +84,8 @@ class Arduino_Portenta_OTA
       OtaHeaderLength      = -5,
       OtaHeaderCrc         = -6,
       OtaHeaterMagicNumber = -7,
+      CaStorageInit        = -8,
+      CaStorageOpen        = -9,
     };
 
              Arduino_Portenta_OTA(StorageTypePortenta const storage_type, uint32_t const data_offset);
@@ -109,6 +111,7 @@ class Arduino_Portenta_OTA
     StorageTypePortenta _storage_type;
     uint32_t _data_offset;
     uint32_t _program_length;
+    mbed::BlockDevice * _bd_raw_qspi;
 
     virtual bool init() = 0;
     virtual bool open() = 0;
@@ -118,6 +121,8 @@ class Arduino_Portenta_OTA
   private:
 
     void write();
+    bool caStorageInit();
+    bool caStorageOpen();
     ArduinoPortentaOtaWatchdogResetFuncPointer _feed_watchdog_func = 0;
 
 };

--- a/src/Arduino_Portenta_OTA.h
+++ b/src/Arduino_Portenta_OTA.h
@@ -37,6 +37,9 @@
 #include <LittleFileSystem.h>
 #include <Arduino_DebugUtils.h>
 
+#include "WiFi.h" /* WiFi from ArduinoCore-mbed */
+#include <SocketHelpers.h>
+
 /******************************************************************************
  * DEFINE
  ******************************************************************************/
@@ -95,7 +98,7 @@ class Arduino_Portenta_OTA
     /* This functionality is intended for usage with the Arduino IoT Cloud for
      * performing OTA firmware updates using the Arduino IoT Cloud servers.
      */
-    int download(const char * url, bool const is_https);
+    int download(const char * url, bool const is_https, MbedSocketClass * socket = static_cast<MbedSocketClass*>(&WiFi));
     int decompress();
     void setFeedWatchdogFunc(ArduinoPortentaOtaWatchdogResetFuncPointer func);
     void feedWatchdog();

--- a/src/Arduino_Portenta_OTA_QSPI.cpp
+++ b/src/Arduino_Portenta_OTA_QSPI.cpp
@@ -46,12 +46,6 @@ Arduino_Portenta_OTA_QSPI::Arduino_Portenta_OTA_QSPI(StorageTypePortenta const s
 
 bool Arduino_Portenta_OTA_QSPI::init()
 {
-  _bd_raw_qspi = mbed::BlockDevice::get_default_instance();
-  if (_bd_raw_qspi->init() != QSPIF_BD_ERROR_OK) {
-    Debug.print(DBG_ERROR, F("Error: QSPI init failure."));
-    return false;
-  }
-
   if(_storage_type == QSPI_FLASH_FATFS)
   {
     _fs_qspi = new mbed::FATFileSystem("fs");
@@ -75,7 +69,6 @@ bool Arduino_Portenta_OTA_QSPI::init()
     }
     return true;
   }
-
   return false;
 }
 

--- a/src/Arduino_Portenta_OTA_QSPI.h
+++ b/src/Arduino_Portenta_OTA_QSPI.h
@@ -48,7 +48,6 @@ protected:
 
 private:
 
-  mbed::BlockDevice * _bd_raw_qspi;
   mbed::BlockDevice * _bd_qspi;
   mbed::FATFileSystem * _fs_qspi;
 };

--- a/src/decompress/utility.cpp
+++ b/src/decompress/utility.cpp
@@ -22,7 +22,6 @@
 
 #include "lzss.h"
 
-#include "WiFi.h" /* WiFi from ArduinoCore-mbed */
 #include "Arduino_Portenta_OTA.h"
 
 /**************************************************************************************
@@ -90,9 +89,9 @@ uint32_t crc_update(uint32_t crc, const void * data, size_t data_len)
    MAIN
  **************************************************************************************/
 
-int Arduino_Portenta_OTA::download(const char * url, bool const is_https)
+int Arduino_Portenta_OTA::download(const char * url, bool const is_https, MbedSocketClass * socket)
 {
-  return WiFi.download((char *)url, UPDATE_FILE_NAME_LZSS, is_https);
+  return socket->download((char *)url, UPDATE_FILE_NAME_LZSS, is_https);
 }
 
 int Arduino_Portenta_OTA::decompress()


### PR DESCRIPTION
This PR enables the use of ethernet interface for the download process of the OTA binary.

Certificates used for download are stored in the `/wlan` partition of the QSPI flash and this partition is mounted only if WiFi interface is used, so i've added two steps in the `begin` function to initialize the `/wlan` partition and check if certificates are present.