### PR TITLE
Fix typos in documentation comments

### DIFF
--- a/examples/OTA_Qspi_Flash/OTA_Qspi_Flash.ino
+++ b/examples/OTA_Qspi_Flash/OTA_Qspi_Flash.ino
@@ -3,7 +3,7 @@
  * a firmware image stored on the QSPI.
  *
  * Steps:
- *   1) Create a sketch for the Portenta H7 and verifiy
+ *   1) Create a sketch for the Portenta H7 and verify
  *      that it both compiles and works on a board.
  *   2) In the IDE select: Sketch -> Export compiled Binary.
  *   3) Create an OTA update file utilising the tools 'lzss.py' and 'bin2ota.py' stored in

--- a/examples/OTA_SD_Portenta/OTA_SD_Portenta.ino
+++ b/examples/OTA_SD_Portenta/OTA_SD_Portenta.ino
@@ -3,7 +3,7 @@
  * a firmware image stored on the SD.
  *
  * Steps:
- *   1) Create a sketch for the Portenta H7 and verifiy
+ *   1) Create a sketch for the Portenta H7 and verify
  *      that it both compiles and works on a board.
  *   2) In the IDE select: Sketch -> Export compiled Binary.
  *   3) Create an OTA update file utilising the tools 'lzss.py' and 'bin2ota.py' stored in

--- a/examples/OTA_Usage_Portenta/OTA_Usage_Portenta.ino
+++ b/examples/OTA_Usage_Portenta/OTA_Usage_Portenta.ino
@@ -1,9 +1,9 @@
 /*
  This sketch can be used to generate an example binary that can be uploaded to Portenta via OTA.
  It needs to be used together with
-  - 'OTA_Qspi_Flash.ino' if you want to use the Qspi Flash as storage system
+  - 'OTA_Qspi_Flash.ino' if you want to use the QSPI Flash as storage system
   OR
-  - 'SD_Qspi_Flash.ino' if you want to use the SD card as storage system
+  - 'OTA_SD_Portenta.ino' if you want to use the SD card as storage system
 
  Steps to test OTA on Portenta:
  1) Upload this sketch or any other sketch (this one lights up the RGB LED with different colours).
@@ -46,13 +46,13 @@ void setup()
 }
 
 void loop()
-{ //led BLUE ON
+{ // Blue LED on
   setLed(1, 0, 0);
   delay(1000);
-  //led GREEN ON
+  // Green LED on
   setLed(0, 1, 0);
   delay(1000);
-  //led RED ON
+  // Red LED on
   setLed(0, 0, 1);
   delay(1000);
 }


### PR DESCRIPTION
An update to the [**codespell**](https://github.com/codespell-project/codespell) tool used for spell checking the content of this repository caught some misspelled words in the documentation contents: misspelling of the word "calculates" caused a failure of the spell check run by the repository's continuous integration system:

https://github.com/arduino-libraries/Arduino_Portenta_OTA/runs/8047636055?check_suite_focus=true#step:4:17

```text
Error: ./examples/OTA_Qspi_Flash/OTA_Qspi_Flash.ino:6: verifiy ==> verify
Error: ./examples/OTA_SD_Portenta/OTA_SD_Portenta.ino:6: verifiy ==> verify
```

I took this as an opportunity to do a comprehensive review and found a couple additional typos.