### PR TITLE
Make isOtaCapable static

### DIFF
--- a/src/Arduino_Portenta_OTA.h
+++ b/src/Arduino_Portenta_OTA.h
@@ -92,7 +92,7 @@ class Arduino_Portenta_OTA
     virtual ~Arduino_Portenta_OTA();
 
 
-    bool  isOtaCapable();
+    static bool  isOtaCapable();
     Error begin();
     Error update();
     void  reset();


### PR DESCRIPTION
isOtaCapable() can be a static method and changing to static makes possible to call it directly from ArduinoIoTCloud like this:

https://github.com/pennam/ArduinoIoTCloud/blob/d0346cbd88fbb81240eef419ea1dfba7fccee9f6/src/ArduinoIoTCloudTCP.cpp#L209

See :https://github.com/arduino-libraries/ArduinoIoTCloud/pull/351