### PR TITLE
Fix regression re report-size-deltas after updating actions/upload-artifact.

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -44,6 +44,7 @@ jobs:
               - examples/OTA_Usage_Portenta
               - examples/LZSS
               - examples/OTA_Qspi_Flash_download_onthefly
+            artifact-name-suffix: arduino-mbed_portenta-envie_m7
           - fqbn: arduino:mbed_nicla:nicla_vision
             platforms: |
               - name: arduino:mbed_nicla
@@ -54,6 +55,7 @@ jobs:
               - examples/OTA_Usage_Portenta
               - examples/LZSS
               - examples/OTA_Qspi_Flash_download_onthefly
+            artifact-name-suffix: arduino-mbed_nicla-nicla_vision
           - fqbn: arduino:mbed_opta:opta
             platforms: |
               - name: arduino:mbed_opta
@@ -65,6 +67,7 @@ jobs:
               - examples/OTA_Usage_Portenta
               - examples/LZSS
               - examples/OTA_Qspi_Flash_download_onthefly
+            artifact-name-suffix: arduino-mbed_opta-opta
           - fqbn: arduino:mbed_giga:giga
             platforms: |
               - name: arduino:mbed_giga
@@ -75,6 +78,7 @@ jobs:
               - examples/OTA_Usage_Portenta
               - examples/LZSS
               - examples/OTA_Qspi_Flash_download_onthefly
+            artifact-name-suffix: arduino-mbed_giga-giga
 
     steps:
       - name: Checkout
@@ -98,5 +102,6 @@ jobs:
       - name: Save memory usage change report as artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ env.SKETCHES_REPORTS_PATH }}
+          if-no-files-found: error
           path: ${{ env.SKETCHES_REPORTS_PATH }}
+          name: sketches-report-${{ matrix.board.artifact-name-suffix }}

--- a/.github/workflows/report-size-deltas.yml
+++ b/.github/workflows/report-size-deltas.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Comment size deltas reports to PRs
         uses: arduino/report-size-deltas@main
         with:
-          # The name of the workflow artifact created by the "Compile Examples" workflow
-          sketches-reports-source: sketches-reports
+          # Regex matching the names of the workflow artifacts created by the "Compile Examples" workflow
+          sketches-reports-source: ^sketches-report-.+


### PR DESCRIPTION
For more information see https://github.com/arduino/report-size-deltas/blob/main/docs/FAQ.md#size-deltas-report-workflow-triggered-by-schedule-event .